### PR TITLE
Main Collage view broken for Plone 4.3.

### DIFF
--- a/Products/Collage/browser/templates/collage_view.pt
+++ b/Products/Collage/browser/templates/collage_view.pt
@@ -28,10 +28,6 @@
           </p>
         </tal:description>
 
-        <div metal:use-macro="here/document_relateditems/macros/relatedItems">
-          show related items if they exist
-        </div>
-
         <div tal:replace="structure provider:plone.abovecontentbody" />
 
         <div tal:replace="structure here/@@renderer">


### PR DESCRIPTION
...//github.com/plone/Products.CMFPlone/commit/90d9ab4e1957fa206cf5ea2d602d691d2ac22c58). This broke the default Collage view as it was using here/document_relateditems/macro/relatedItems. This would probably break pre-Plone4 setups where the relatedItems viewlet is not in place, maybe it's worth to note it in the documentation.
